### PR TITLE
Allow slugs to handle Ash.CiString values

### DIFF
--- a/lib/ash_slug/changes/slugify.ex
+++ b/lib/ash_slug/changes/slugify.ex
@@ -50,7 +50,7 @@ defmodule AshSlug.Changes.Slugify do
     Ash.Changeset.before_action(changeset, fn changeset ->
       with {attribute, opts} <- Keyword.pop(opts, :attribute),
            {into, opts} <- Keyword.pop(opts, :into, attribute),
-           {:ok, value} when is_binary(value) <- Ash.Changeset.fetch_argument_or_change(changeset, attribute),
+           {:ok, value} when is_binary(value) <- get_attribute(changeset, attribute),
            slug <- Slug.slugify(value, opts) do
         changeset
         |> Ash.Changeset.force_change_attribute(into, slug)
@@ -59,6 +59,13 @@ defmodule AshSlug.Changes.Slugify do
         :error -> changeset
       end
     end)
+  end
+
+  defp get_attribute(changeset, attribute) do
+    case Ash.Changeset.fetch_argument_or_change(changeset, attribute) do
+      {:ok, %Ash.CiString{} = value} -> {:ok, Ash.CiString.value(value)}
+      res -> res
+    end
   end
 
   @spec replace_lowercase_opts(Keyword.t()) :: Keyword.t()

--- a/test/ash_slug_test.exs
+++ b/test/ash_slug_test.exs
@@ -15,11 +15,11 @@ defmodule AshSlugTest do
   test "ensure Ash.CiString value is slugified" do
     resource =
       AshSlugTest.Resource
-      |> Ash.Changeset.for_create(:create, %{text1: Ash.CiString.new("Hello, World!")})
+      |> Ash.Changeset.for_create(:create, %{text3: Ash.CiString.new("Hello, World!")})
       |> Ash.Changeset.set_context(%{foo: :bar})
       |> Ash.create!()
 
-    assert resource.text1 == "Hello-World"
+    assert resource.text3_slug == "hello-world"
   end
 
   test "ensure value is slugified into another attribute" do

--- a/test/ash_slug_test.exs
+++ b/test/ash_slug_test.exs
@@ -12,6 +12,16 @@ defmodule AshSlugTest do
     assert resource.text1 == "Hello-World"
   end
 
+  test "ensure Ash.CiString value is slugified" do
+    resource =
+      AshSlugTest.Resource
+      |> Ash.Changeset.for_create(:create, %{text1: Ash.CiString.new("Hello, World!")})
+      |> Ash.Changeset.set_context(%{foo: :bar})
+      |> Ash.create!()
+
+    assert resource.text1 == "Hello-World"
+  end
+
   test "ensure value is slugified into another attribute" do
     resource =
       AshSlugTest.Resource

--- a/test/support/resource.ex
+++ b/test/support/resource.ex
@@ -15,15 +15,18 @@ defmodule AshSlugTest.Resource do
     attribute(:text1, :string, public?: true)
     attribute(:text2, :string, public?: true)
     attribute(:text2_slug, :string)
+    attribute(:text3, :ci_string, public?: true)
+    attribute(:text3_slug, :string)
     attribute(:bool, :boolean, public?: true)
   end
 
   actions do
     create :create do
-      accept([:text1, :text2, :bool])
+      accept([:text1, :text2, :text3, :bool])
 
       change(slugify(:text1, lowercase?: false))
       change(slugify(:text2, into: :text2_slug))
+      change(slugify(:text3, into: :text3_slug))
       change(slugify(:bool))
     end
   end


### PR DESCRIPTION
I created this PR to address an issue I have run into with records where I'd like both the slug and name to be unique in a case-insensitive manner. Since citext is a common solution for this, I wanted to make sure that this library can handle source attributes that are of the type `Ash.CiString`.

This adds a new helper function in the `AshSlug.Changes.Slugify` module to get an attribute and convert it into a binary. I enabled support for binaries and `Ash.CiString` values.

I additionally added a test to verify that the behavior is doing what we'd expect with some help from @barnabasJ.

Let me know if I need to make any adjustments.

Thanks!

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
